### PR TITLE
Update aggregation to new aggregate-data endpoint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,5 +15,8 @@ Imports:
     stringr,
     tidyr,
     dplyr,
-    magrittr
+    magrittr,
+    tibble
+Suggests:
+    testthat
 RoxygenNote: 6.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lanar
 Type: Package
 Title: Process Data from a Lana model
-Version: 0.1.0
+Version: 1.1.0
 Author: Lana Labs GmbH
 Maintainer: Lana Labs GmbH <support@lana-labs.com>
 Description: The lanar package let's you work with the uploaded data and the corresponding model from your Lana software. You can use this package to extract different aggregations of the data within lana as well as activity performance statisitics. Look at the examples to get an understanding of what you can do and also have a look at https://api.lana-labs.com/ for further information.
@@ -13,5 +13,7 @@ Imports:
     httr,
     plyr,
     stringr,
-    tidyr
+    tidyr,
+    dplyr,
+    magrittr
 RoxygenNote: 6.1.0

--- a/R/aggregationData.R
+++ b/R/aggregationData.R
@@ -142,7 +142,6 @@ aggregate <- function(lanaUrl, lanaToken, logId, xDimension, yDimension, zDimens
   
   request_data <- list(
     metric = build_request_metric(yDimension),
-    grouping = build_request_grouping(xDimension),
     valuesFrom = list(
       type = "allCases"
     ),
@@ -153,7 +152,11 @@ aggregate <- function(lanaUrl, lanaToken, logId, xDimension, yDimension, zDimens
     miningRequest = mining_request_data,
     type = type
   )
-  
+
+  if (xDimension != "noAggregation") {
+    request_data[["grouping"]] <- build_request_grouping(xDimension)
+  }  
+    
   if (zDimension != "null") {
     request_data[["secondaryGrouping"]] <- build_request_grouping(zDimension)
   }

--- a/R/aggregationData.R
+++ b/R/aggregationData.R
@@ -163,14 +163,14 @@ aggregate <- function(lanaUrl, lanaToken, logId, xDimension, yDimension, zDimens
     body = list(request = jsonlite::toJSON(request_data, auto_unbox = TRUE)),
     encode = "multipart",
     httr::add_headers(header_fields)
-    #httr::verbose()
   )
   
-  #httr::http_status(r)$message
+  checkHttpErrors(r)
   
   content <- jsonlite::fromJSON(httr::content(r, as = "text", encoding = "UTF-8"))
   
-  chart_values <- content$chartValues
+  chart_values <- content$chartValues %>%
+    select(-`$type`)
   
   if(zDimension != "null"){
     chart_values %<>% 

--- a/R/aggregationData.R
+++ b/R/aggregationData.R
@@ -225,8 +225,8 @@ aggregate <- function(lanaUrl, lanaToken, logId, xDimension = "noAggregation", y
   chartValues <- content$chartValues
   
   if(zDimension != "null"){
-    chartValues %<>% 
-      unnest(values, names_repair = "unique")
+    chartValues <- chartValues %>%
+      tidyr::unnest(values, names_repair = "unique")
   }
   
   names(chartValues)[names(chartValues) == "xAxis"] <- gsub(".*=", "", xDimension)

--- a/R/aggregationData.R
+++ b/R/aggregationData.R
@@ -222,8 +222,7 @@ aggregate <- function(lanaUrl, lanaToken, logId, xDimension = "noAggregation", y
   
   content <- jsonlite::fromJSON(httr::content(r, as = "text", encoding = "UTF-8"))
   
-  chartValues <- content$chartValues %>%
-    select(-`$type`)
+  chartValues <- content$chartValues
   
   if(zDimension != "null"){
     chartValues %<>% 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+# How to test
+
+* tests require access to a lana api
+* we require the user has access to the log `Incident_management.csv`
+* credentials have to be provided in the file `/testthat/config.R`
+    ```R
+      lanaUrl <- “<URL of LANA instance>”
+      selectedLogId <- “<LogId of Incident_management.csv>“
+      lanaToken <- “<apiKey>”
+    ```

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,2 @@
+library(testthat)
+test_check(lanar)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,2 +1,4 @@
 library(testthat)
+library(lanar)
+
 test_check("lanar")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,2 +1,2 @@
 library(testthat)
-test_check(lanar)
+test_check("lanar")

--- a/tests/testthat/config.R
+++ b/tests/testthat/config.R
@@ -1,0 +1,3 @@
+lanaUrl <- ""
+selectedLogId <- ""
+lanaToken <- ""

--- a/tests/testthat/test-aggregationData.R
+++ b/tests/testthat/test-aggregationData.R
@@ -1,4 +1,4 @@
-context("Test context for basic functions")
+context("Test context for aggregation function")
 source("config.R")
 
 #the expected data frames were generated with the old aggregate-function calling the /api/aggregatedData endpoint or via the LANA frontend

--- a/tests/testthat/test_aggregation.R
+++ b/tests/testthat/test_aggregation.R
@@ -1,0 +1,90 @@
+source("config.R")
+
+#the expected data frames were generated with the old aggregate-function calling the /api/aggregatedData endpoint or via the LANA frontend
+
+test_that("aggregations with attribute and time groupings return the expected dataframe", {
+  df_aggregation <- aggregate(xDimension = "byAttribute=Country",
+                              yDimension = "frequency",
+                              zDimension = "byTime=byMonth",
+                              traceFilterSequence = "[]",
+                              lanaToken = lanaToken,
+                              lanaUrl = lanaUrl,
+                              logId = selectedLogId,
+                              aggregationFunction = "mean",
+                              aggrLevel = "events")
+  
+  caseCount <- c(891, 557, 363, 189) 
+  Country <- c("Germany", "Austria", "Netherlands", "Switzerland") 
+  frequency <- c(891, 557, 363, 189) 
+  byMonth <- c("Jan 2016", "Jan 2016", "Jan 2016", "Jan 2016")
+  
+  df_expected <- data.frame(caseCount, Country, frequency, byMonth, stringsAsFactors = FALSE) %>%
+    mutate(caseCount = as.integer(caseCount), frequency = as.integer(frequency)) %>%
+    as_tibble()
+  
+  testthat::expect_identical(df_expected, df_aggregation)
+
+})
+
+test_that("aggregations with numeric attribute metrics return the expected dataframe", {
+  df_aggregation <- aggregate(yDimension = "byAttribute=Cost",
+                              traceFilterSequence = "[]",
+                              lanaToken = lanaToken,
+                              lanaUrl = lanaUrl,
+                              logId = selectedLogId,
+                              aggregationFunction = "sum",
+                              aggrLevel = "traces")
+  
+  caseCount <- c(2000) 
+  noAggregation <- c("No grouping") 
+  Cost <- c(8536000)
+  
+  df_expected <- data.frame(caseCount, noAggregation, Cost, stringsAsFactors = FALSE) %>%
+    mutate(caseCount = as.integer(caseCount), Cost = as.integer(Cost))
+  
+  testthat::expect_identical(df_expected, df_aggregation)
+  
+})
+
+test_that("aggregations with specified valueSorting and sortingOrder return the expected dataframe", {
+  df_aggregation <- aggregate(xDimension = "Classification",
+                              yDimension = "avgDuration",
+                              traceFilterSequence = "[]",
+                              lanaToken = lanaToken,
+                              lanaUrl = lanaUrl,
+                              logId = selectedLogId,
+                              aggrLevel = "allCases",
+                              valueSorting = "alphabetic",
+                              sortingOrder = "ascending")
+  
+  caseCount <- c(109, 295, 57, 610, 929) 
+  Classification <- c("Backup", "Citrix", "Intranet", "Mail", "SAP") 
+  avgDuration <- c(23770458.715596333, 63067525.423728816, 22307368.421052627, 27052327.868852418, 49583186.221743822)
+  
+  df_expected <- data.frame(caseCount, Classification, avgDuration, stringsAsFactors = FALSE) %>%
+    mutate(caseCount = as.integer(caseCount))
+  
+  testthat::expect_identical(df_expected, df_aggregation)
+  
+})
+
+test_that("aggregations with a traceFilterSequence and maxValueAmount return the expected dataframe", {
+  df_aggregation <- aggregate(xDimension = "byTime=byHour",
+                              yDimension = "byAttribute=Cost",
+                              traceFilterSequence = '[{"pre":"Incident classification","succ":"Functional escalation","direct":false,"useDuration":false,"type":"followerFilter","inverted":false}]',
+                              maxValueAmount = 9,
+                              lanaToken = lanaToken,
+                              lanaUrl = lanaUrl,
+                              logId = selectedLogId,
+                              aggrLevel = "events")
+  
+  caseCount <- c(1080, 978, 762, 368, 281, 142, 140, 139, 133, 1677) 
+  byHour <- c("13", "12", "14", "11", "15", "23", "16", "6", "4", "Other") 
+  Cost <- c(146000, 120000, 162000, 176000, 109000, 94000, 64000, 168000, 149000, 2223000)
+  
+  df_expected <- data.frame(caseCount, byHour, Cost, stringsAsFactors = FALSE) %>%
+    mutate(caseCount = as.integer(caseCount), Cost = as.integer(Cost))
+  
+  testthat::expect_identical(df_expected, df_aggregation)
+  
+})

--- a/tests/testthat/test_aggregation.R
+++ b/tests/testthat/test_aggregation.R
@@ -20,8 +20,8 @@ test_that("aggregations with attribute and time groupings return the expected da
   byMonth <- c("Jan 2016", "Jan 2016", "Jan 2016", "Jan 2016")
 
   df_expected <- data.frame(caseCount, Country, frequency, byMonth, stringsAsFactors = FALSE) %>%
-    mutate(caseCount = as.integer(caseCount), frequency = as.integer(frequency)) %>%
-    as_tibble()
+    dplyr::mutate(caseCount = as.integer(caseCount), frequency = as.integer(frequency)) %>%
+    tibble::as_tibble()
 
   testthat::expect_identical(df_expected, df_aggregation)
 
@@ -41,7 +41,7 @@ test_that("aggregations with numeric attribute metrics return the expected dataf
   Cost <- c(8536000)
 
   df_expected <- data.frame(caseCount, noAggregation, Cost, stringsAsFactors = FALSE) %>%
-    mutate(caseCount = as.integer(caseCount), Cost = as.integer(Cost))
+    dplyr::mutate(caseCount = as.integer(caseCount), Cost = as.integer(Cost))
 
   testthat::expect_identical(df_expected, df_aggregation)
 
@@ -63,7 +63,7 @@ test_that("aggregations with specified valueSorting and sortingOrder return the 
   avgDuration <- c(23770458.715596333, 63067525.423728816, 22307368.421052627, 27052327.868852418, 49583186.221743822)
 
   df_expected <- data.frame(caseCount, Classification, avgDuration, stringsAsFactors = FALSE) %>%
-    mutate(caseCount = as.integer(caseCount))
+    dplyr::mutate(caseCount = as.integer(caseCount))
 
   testthat::expect_identical(df_expected, df_aggregation)
 
@@ -84,7 +84,7 @@ test_that("aggregations with a traceFilterSequence and maxValueAmount return the
   Cost <- c(146000, 120000, 162000, 176000, 109000, 94000, 64000, 168000, 149000, 2223000)
 
   df_expected <- data.frame(caseCount, byHour, Cost, stringsAsFactors = FALSE) %>%
-    mutate(caseCount = as.integer(caseCount), Cost = as.integer(Cost))
+    dplyr::mutate(caseCount = as.integer(caseCount), Cost = as.integer(Cost))
 
   testthat::expect_identical(df_expected, df_aggregation)
 

--- a/tests/testthat/test_aggregation.R
+++ b/tests/testthat/test_aggregation.R
@@ -1,3 +1,4 @@
+context("Test context for basic functions")
 source("config.R")
 
 #the expected data frames were generated with the old aggregate-function calling the /api/aggregatedData endpoint or via the LANA frontend
@@ -12,16 +13,16 @@ test_that("aggregations with attribute and time groupings return the expected da
                               logId = selectedLogId,
                               aggregationFunction = "mean",
                               aggrLevel = "events")
-  
-  caseCount <- c(891, 557, 363, 189) 
-  Country <- c("Germany", "Austria", "Netherlands", "Switzerland") 
-  frequency <- c(891, 557, 363, 189) 
+
+  caseCount <- c(891, 557, 363, 189)
+  Country <- c("Germany", "Austria", "Netherlands", "Switzerland")
+  frequency <- c(891, 557, 363, 189)
   byMonth <- c("Jan 2016", "Jan 2016", "Jan 2016", "Jan 2016")
-  
+
   df_expected <- data.frame(caseCount, Country, frequency, byMonth, stringsAsFactors = FALSE) %>%
     mutate(caseCount = as.integer(caseCount), frequency = as.integer(frequency)) %>%
     as_tibble()
-  
+
   testthat::expect_identical(df_expected, df_aggregation)
 
 })
@@ -34,16 +35,16 @@ test_that("aggregations with numeric attribute metrics return the expected dataf
                               logId = selectedLogId,
                               aggregationFunction = "sum",
                               aggrLevel = "traces")
-  
-  caseCount <- c(2000) 
-  noAggregation <- c("No grouping") 
+
+  caseCount <- c(2000)
+  noAggregation <- c("No grouping")
   Cost <- c(8536000)
-  
+
   df_expected <- data.frame(caseCount, noAggregation, Cost, stringsAsFactors = FALSE) %>%
     mutate(caseCount = as.integer(caseCount), Cost = as.integer(Cost))
-  
+
   testthat::expect_identical(df_expected, df_aggregation)
-  
+
 })
 
 test_that("aggregations with specified valueSorting and sortingOrder return the expected dataframe", {
@@ -56,16 +57,16 @@ test_that("aggregations with specified valueSorting and sortingOrder return the 
                               aggrLevel = "allCases",
                               valueSorting = "alphabetic",
                               sortingOrder = "ascending")
-  
-  caseCount <- c(109, 295, 57, 610, 929) 
-  Classification <- c("Backup", "Citrix", "Intranet", "Mail", "SAP") 
+
+  caseCount <- c(109, 295, 57, 610, 929)
+  Classification <- c("Backup", "Citrix", "Intranet", "Mail", "SAP")
   avgDuration <- c(23770458.715596333, 63067525.423728816, 22307368.421052627, 27052327.868852418, 49583186.221743822)
-  
+
   df_expected <- data.frame(caseCount, Classification, avgDuration, stringsAsFactors = FALSE) %>%
     mutate(caseCount = as.integer(caseCount))
-  
+
   testthat::expect_identical(df_expected, df_aggregation)
-  
+
 })
 
 test_that("aggregations with a traceFilterSequence and maxValueAmount return the expected dataframe", {
@@ -77,14 +78,14 @@ test_that("aggregations with a traceFilterSequence and maxValueAmount return the
                               lanaUrl = lanaUrl,
                               logId = selectedLogId,
                               aggrLevel = "events")
-  
-  caseCount <- c(1080, 978, 762, 368, 281, 142, 140, 139, 133, 1677) 
-  byHour <- c("13", "12", "14", "11", "15", "23", "16", "6", "4", "Other") 
+
+  caseCount <- c(1080, 978, 762, 368, 281, 142, 140, 139, 133, 1677)
+  byHour <- c("13", "12", "14", "11", "15", "23", "16", "6", "4", "Other")
   Cost <- c(146000, 120000, 162000, 176000, 109000, 94000, 64000, 168000, 149000, 2223000)
-  
+
   df_expected <- data.frame(caseCount, byHour, Cost, stringsAsFactors = FALSE) %>%
     mutate(caseCount = as.integer(caseCount), Cost = as.integer(Cost))
-  
+
   testthat::expect_identical(df_expected, df_aggregation)
-  
+
 })


### PR DESCRIPTION
## Description
The purpose of this PR is to update the `aggregate`-function to send requests to the endpoint `api/v2/aggregate-data/` while keeping compatibility to old calls to the function in order to not break existing RShiny dashboards that use `lanar::aggregate`.

The new endpoint changed the structure and expected parameters of the request data, so part of the changes in the PR are translations of the old x/y/z-dimensions into the new metrics and groupings.

## What was changed
* Request is sent to `api/v2/aggregate-data/` endpoint
* `yDimension` is translated as metric; frequency, numeric attributes and old duration aggregations are translated into the required structure of the new endpoint
* `xDimension` and `zDimension` are translated to optional groupings; original `byTime=` or `byAttribute=` prefixes are translated into the required structure of the new endpoint
* `aggregationFunction`, `valueSorting` and `sortingOrder` are added as optional parameters
* Requests are built with nested lists that are converted to JSONs instead of using `paste0()` to increase readability
* Implemented first tests for `aggregate`-function

## What is not part of this PR
* The original aggregate-function didn’t have a functioning option to define followers ([follower parameter was overwritten](https://github.com/lanalabs/LanaR/blob/56dc9e1164cf2ae3330417ab0f90e7165d41dea8/R/aggregationData.R#L9-L11)), this is also not implemented in the current `aggregate`-function.
* Configuration of `dateType` for the groupings was not part of the old `aggregate`-function and was not included in this PR, the value `”startDate"` is always used
* No activity aggregations are handled right now

## Testing
In addition to the tests found in `/tests/testthat/test_aggregation.R`, the updated package was tested with the P2P and O2C dashboards

## Work that spawns from this
The next steps are to unravel the `aggregate`-function into various smaller functions like `getMinCaseDuration()` or `getCaseCountByMonth()` in order to increase the usability of the package and take advantage of the new features of the `/api/v2/aggregated-data/` endpoint. 